### PR TITLE
Changed deployment dir for data to '/' schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def package_files(directory):
 
 setup(
     name="ystafdb",
-    version="0.6.0",
+    version="0.6.1",
     packages=packages,
     description="CLI tool to parse YSTAFDB and produce ttl/nt/xml.",
     long_description=open("README.md").read(),

--- a/ystafdb/ystafdb_metadata.py
+++ b/ystafdb/ystafdb_metadata.py
@@ -239,7 +239,7 @@ def generate_ystafdb_metadata_uris(args):
     bloc = Namespace("http://rdf.bonsai.uno/location/ystafdb#")
 
     g.bind("bont", "http://ontology.bonsai.uno/core#")
-    g.bind("flow", "http://rdf.bonsai.uno/data/ystafdb/huse#")
+    g.bind("flow", "http://rdf.bonsai.uno/data/ystafdb/huse/")
     g.bind("schema", "http://schema.org/")
     g.bind("brdffo", "http://rdf.bonsai.uno/flowobject/ystafdb#")
     g.bind("om2", "http://www.ontology-of-units-of-measure.org/resource/om-2/")


### PR DESCRIPTION

Changes:
- Changed deployment schema from '#' to '/' for all triples deployed under 'data'.
- Changed version number '0.6.0' -> '0.6.1'

This fixes #19